### PR TITLE
refactor: remove unused error wrapping function

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -22,12 +22,6 @@ async function parseFetchResponse(response: Response, options: CustomRequestOpti
   return await response.text()
 }
 
-function wrapInError(reject: (...args: any) => void) {
-  return (err: Error): void => {
-    reject(new PlusAuthRestError(err))
-  }
-}
-
 /**
  * @internal
  */


### PR DESCRIPTION
## Description

Removed the unused `wrapInError` helper function from `src/http.ts`. This function was defined but never called anywhere in the codebase, making it dead code.